### PR TITLE
feat: 상품 엔티티에 브랜드와 카테고리 컬럼을 추가

### DIFF
--- a/src/main/java/com/woowa/woowakit/domain/product/domain/Product.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/Product.java
@@ -1,9 +1,14 @@
 package com.woowa.woowakit.domain.product.domain;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -18,6 +23,7 @@ import com.woowa.woowakit.domain.model.Quantity;
 import com.woowa.woowakit.domain.product.exception.UpdateProductStatusFailException;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -52,13 +58,25 @@ public class Product extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private ProductStatus status;
 
+	@ElementCollection
+	@Column(name = "category")
+	@Enumerated(EnumType.STRING)
+	private Set<ProductCategory> categories = new HashSet<>();
+
+	@Column(name = "brand")
+	@Enumerated(EnumType.STRING)
+	private ProductBrand productBrand;
+
+	@Builder
 	private Product(
 		final Long id,
 		final String name,
 		final long price,
 		final String imageUrl,
 		final ProductStatus status,
-		final long quantity
+		final long quantity,
+		final ProductBrand productBrand,
+		final List<ProductCategory> productCategories
 	) {
 		this.id = id;
 		this.name = ProductName.from(name);
@@ -66,6 +84,15 @@ public class Product extends BaseEntity {
 		this.imageUrl = ProductImage.from(imageUrl);
 		this.status = status;
 		this.quantity = Quantity.from(quantity);
+		this.productBrand = productBrand;
+		this.categories = setCategories(productCategories);
+	}
+
+	private HashSet<ProductCategory> setCategories(final List<ProductCategory> productCategories) {
+		if (productCategories.isEmpty()) {
+			return new HashSet<>(List.of(ProductCategory.ETC));
+		}
+		return new HashSet<>(productCategories);
 	}
 
 	public void updateProductStatus(final ProductStatus productStatus) {
@@ -127,6 +154,8 @@ public class Product extends BaseEntity {
 		private String imageUrl;
 		private ProductStatus status = ProductStatus.PRE_REGISTRATION;
 		private long quantity;
+		private ProductBrand productBrand = ProductBrand.NONE;
+		private List<ProductCategory> productCategories = new ArrayList<>();
 
 		ProductBuilder() {
 		}
@@ -161,8 +190,25 @@ public class Product extends BaseEntity {
 			return this;
 		}
 
+		public ProductBuilder productBrand(final ProductBrand productBrand) {
+			this.productBrand = productBrand;
+			return this;
+		}
+
+		public ProductBuilder productCategories(final List<ProductCategory> productCategories) {
+			this.productCategories = productCategories;
+			return this;
+		}
+
 		public Product build() {
-			return new Product(this.id, this.name, this.price, this.imageUrl, this.status, this.quantity);
+			return new Product(this.id, this.name, this.price, this.imageUrl, this.status, this.quantity,
+				this.productBrand, this.productCategories);
+		}
+
+		public String toString() {
+			return "Product.ProductBuilder(id=" + this.id + ", name=" + this.name + ", price=" + this.price
+				+ ", imageUrl=" + this.imageUrl + ", status=" + this.status + ", quantity=" + this.quantity
+				+ ", productBrand=" + this.productBrand + ", productCategories=" + this.productCategories + ")";
 		}
 	}
 

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/ProductBrand.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/ProductBrand.java
@@ -1,0 +1,18 @@
+package com.woowa.woowakit.domain.product.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ProductBrand {
+
+	FRESH_EASY("프레시지"),
+	MOKRAN("이연복의 목란"),
+	MYCHEF("마이셰프"),
+	SIMPLY_COOK("심플리쿡"),
+	COOKIT("국킷"),
+	NONE("-");
+
+	private final String name;
+}

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/ProductCategory.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/ProductCategory.java
@@ -1,0 +1,17 @@
+package com.woowa.woowakit.domain.product.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ProductCategory {
+
+	WESTERN("양식"),
+	JAPANESE("일식"),
+	CHINESE("중식"),
+	KOREAN("한식"),
+	ETC("-");
+
+	private final String name;
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
 drop table if exists members;
+drop table if exists product_categories;
 drop table if exists products;
 drop table if exists stocks;
 drop table if exists orders;
@@ -8,50 +9,57 @@ drop table if exists cart_items;
 
 create table if not exists members
 (
-    id bigint auto_increment not null,
-    name varchar(255) not null,
-    email varchar(255) not null unique,
-    password varchar(255) not null,
-    role varchar(255) not null,
-    primary key(id)
+    id       bigint auto_increment not null,
+    name     varchar(255)          not null,
+    email    varchar(255)          not null unique,
+    password varchar(255)          not null,
+    role     varchar(255)          not null,
+    primary key (id)
+);
+
+create table if not exists product_categories
+(
+    product_id bigint not null,
+    category   varchar(255)
 );
 
 create table if not exists products
 (
-    id bigint auto_increment not null,
-    name varchar(255) not null,
-    image_url varchar(255),
-    price bigint not null,
-    status varchar(255) not null,
-    quantity bigint not null,
-    created_at datetime not null,
-    updated_at datetime not null,
+    id         bigint auto_increment not null,
+    name       varchar(255)          not null,
+    image_url  varchar(255),
+    price      bigint                not null,
+    quantity   bigint                not null,
+    status     varchar(255)          not null,
+    brand      varchar(255)          not null,
+    created_at datetime              not null,
+    updated_at datetime              not null,
     primary key (id)
 );
 
 create table if not exists stocks
 (
-    id bigint auto_increment not null,
-    expiry_date date not null,
-    quantity bigint not null,
-    product_id bigint not null,
-    stock_type varchar(255),
-    created_at datetime not null,
-    updated_at datetime not null,
+    id          bigint auto_increment not null,
+    expiry_date date                  not null,
+    quantity    bigint                not null,
+    product_id  bigint                not null,
+    stock_type  varchar(255),
+    created_at  datetime              not null,
+    updated_at  datetime              not null,
     primary key (id)
 );
 
 CREATE TABLE if not exists order_items
 (
-    id bigint auto_increment not null,
+    id         bigint auto_increment not null,
     order_id   bigint,
-    product_id bigint       not null,
-    name       varchar(20)  not null,
-    image      varchar(255) not null,
-    price      bigint          not null,
-    quantity   bigint          not null,
-    created_at datetime not null,
-    updated_at datetime not null,
+    product_id bigint                not null,
+    name       varchar(20)           not null,
+    image      varchar(255)          not null,
+    price      bigint                not null,
+    quantity   bigint                not null,
+    created_at datetime              not null,
+    updated_at datetime              not null,
     primary key (id)
 );
 
@@ -59,45 +67,45 @@ CREATE TABLE if not exists order_items
 
 create table if not exists orders
 (
-    id bigint auto_increment not null,
-    order_status varchar(255) not null,
-    total_price bigint not null,
-    member_id bigint not null,
-    uuid varchar(255) not null,
-    created_at datetime not null,
-    updated_at datetime not null,
+    id           bigint auto_increment not null,
+    order_status varchar(255)          not null,
+    total_price  bigint                not null,
+    member_id    bigint                not null,
+    uuid         varchar(255)          not null,
+    created_at   datetime              not null,
+    updated_at   datetime              not null,
     primary key (id)
 );
 
 create table if not exists payments
 (
-    id bigint auto_increment not null,
-    order_id bigint not null,
-    payment_key varchar(255) not null,
-    total_price bigint not null,
-    created_at datetime not null,
-    updated_at datetime not null,
+    id          bigint auto_increment not null,
+    order_id    bigint                not null,
+    payment_key varchar(255)          not null,
+    total_price bigint                not null,
+    created_at  datetime              not null,
+    updated_at  datetime              not null,
     primary key (id)
 );
 
 create table if not exists cart_items
 (
-    id bigint auto_increment not null,
-    member_id bigint not null,
-    product_id bigint not null,
-    quantity   bigint not null,
-    created_at datetime not null,
-    updated_at datetime not null,
-    primary key(id)
+    id         bigint auto_increment not null,
+    member_id  bigint                not null,
+    product_id bigint                not null,
+    quantity   bigint                not null,
+    created_at datetime              not null,
+    updated_at datetime              not null,
+    primary key (id)
 );
 
 create table if not exists product_sales
 (
-    id bigint auto_increment not null,
-    product_id bigint not null,
-    sale bigint not null,
-    sale_date   date not null,
-    created_at datetime not null,
-    updated_at datetime not null,
-    primary key(id)
+    id         bigint auto_increment not null,
+    product_id bigint                not null,
+    sale       bigint                not null,
+    sale_date  date                  not null,
+    created_at datetime              not null,
+    updated_at datetime              not null,
+    primary key (id)
 );

--- a/src/test/java/com/woowa/woowakit/domain/product/domain/ProductTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/product/domain/ProductTest.java
@@ -2,6 +2,8 @@ package com.woowa.woowakit.domain.product.domain;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -94,6 +96,44 @@ class ProductTest {
 		assertThat(product.getStatus()).isEqualTo(ProductStatus.SOLD_OUT);
 	}
 
+	@Test
+	@DisplayName("상품의 브랜드를 별도로 설정하지 않으면 NONE 이다.")
+	void NoConfigureProductBrandThenNone() {
+		Product product = getProduct();
+
+		assertThat(product.getProductBrand()).isEqualTo(ProductBrand.NONE);
+	}
+
+	@Test
+	@DisplayName("상품의 브랜드를 설정할 수 있다.")
+	void configureProductBrand() {
+		ProductBrand brand = ProductBrand.MYCHEF;
+		Product product = getProduct(brand);
+
+		assertThat(product.getProductBrand()).isEqualTo(brand);
+	}
+
+	@Test
+	@DisplayName("상품의 카테고리를 별도로 설정하지 않으면 ETC 이다.")
+	void NoConfigureProductCategoryThenETC() {
+		Product product = getProduct();
+
+		assertThat(product.getCategories())
+			.hasSize(1)
+			.contains(ProductCategory.ETC);
+	}
+
+	@Test
+	@DisplayName("상품의 카테고리를 여러개 설정할 수 있다.")
+	void configureProductCategory() {
+		List<ProductCategory> categories = List.of(ProductCategory.CHINESE, ProductCategory.WESTERN);
+		Product product = getProduct(categories);
+
+		assertThat(product.getCategories())
+			.hasSize(2)
+			.contains(ProductCategory.CHINESE, ProductCategory.WESTERN);
+	}
+
 	private Product getInStockProduct(final ProductStatus status) {
 		return ProductFixture.getInStockProductBuilder()
 			.status(status)
@@ -103,6 +143,18 @@ class ProductTest {
 	private Product getInStockProduct(final long quantity) {
 		return ProductFixture.getInStockProductBuilder()
 			.quantity(quantity)
+			.build();
+	}
+
+	private Product getProduct(final ProductBrand brand) {
+		return ProductFixture.getProductBuilder()
+			.productBrand(brand)
+			.build();
+	}
+
+	private Product getProduct(final List<ProductCategory> productCategories) {
+		return ProductFixture.getProductBuilder()
+			.productCategories(productCategories)
 			.build();
 	}
 


### PR DESCRIPTION

## Description
상품에 대한 고도화 작업으로 상품 브랜드와 카테고리 개념을 추가

## Changes

- 카테고리와 상품 브랜드의 경우 enum 타입으로 시작 추후 필요하면 엔티티로 변경
- 카테고리의 경우 여러 개를 가질 수 있고 상품의 카테고리 항목의 변화가 적을 것으로 예상되어 값타입 컬렉션을 사용
- 브랜드의 경우에는 한 개만을 가질 수 있기 때문에 단순 Enum 처리

## Test Checklist
- 상품의 브랜드를 별도로 설정하지 않으면 NONE 이다
- 상품의 브랜드를 설정할 수 있다
- 상품의 카테고리를 별도로 설정하지 않으면 ETC 이다
- 상품의 카테고리를 여러개 설정할 수 있다
