### PR TITLE
쿠폰 발급이 롤백되었을 때 발급 수량 저장소도 롤백

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:7.1.0'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/woowa/woowakit/domain/coupon/domain/CouponDeployAmountRepository.java
+++ b/src/main/java/com/woowa/woowakit/domain/coupon/domain/CouponDeployAmountRepository.java
@@ -6,6 +6,8 @@ public interface CouponDeployAmountRepository {
 
     void decrease(final CouponGroup couponGroup);
 
+    void increase(final CouponGroup couponGroup);
+
     int getCouponDeployAmount(final Long couponGroupId);
 
     void clear(final Long couponGroupId);

--- a/src/main/java/com/woowa/woowakit/infra/coupon/CouponDeployAmountCacheRepository.java
+++ b/src/main/java/com/woowa/woowakit/infra/coupon/CouponDeployAmountCacheRepository.java
@@ -21,10 +21,18 @@ public class CouponDeployAmountCacheRepository implements CouponDeployAmountRepo
 
     @Override
     public void decrease(final CouponGroup couponGroup) {
+        if (!couponGroup.isLimitType()) {
+            return;
+        }
         long amount = redisTemplate.opsForValue().decrement(getKey(couponGroup.getId()));
         if (amount < 0) {
             throw new ExhaustedCouponDeployAmountException();
         }
+    }
+
+    @Override
+    public void increase(final CouponGroup couponGroup) {
+        redisTemplate.opsForValue().increment(getKey(couponGroup.getId()));
     }
 
     @Override

--- a/src/test/java/com/woowa/woowakit/domain/coupon/domain/CouponDeployAmountMemoryRepository.java
+++ b/src/test/java/com/woowa/woowakit/domain/coupon/domain/CouponDeployAmountMemoryRepository.java
@@ -16,10 +16,21 @@ public class CouponDeployAmountMemoryRepository implements CouponDeployAmountRep
 
     @Override
     public void decrease(final CouponGroup couponGroup) {
+        if (!couponGroup.isLimitType()) {
+            return;
+        }
         Long decrement = decrement(couponGroup);
         if (decrement < 0) {
             throw new ExhaustedCouponDeployAmountException();
         }
+    }
+
+    @Override
+    public void increase(final CouponGroup couponGroup) {
+        if (!couponGroup.isLimitType()) {
+            return;
+        }
+        store.put(getKey(couponGroup.getId()), store.get(getKey(couponGroup.getId())) + 1);
     }
 
     private synchronized Long decrement(final CouponGroup couponGroup) {


### PR DESCRIPTION
## Description
- 발생할 수 있는 예외를 잡은 뒤 감소한 수량만큼 증가시켜주고 예외를 다시 던져 롤백한다.

## Changes

## Test Checklist
```java

    @Test
    @DisplayName("쿠폰그룹이 만료되었다면 사용자 쿠폰을 생성하는데 실패한다.")
    void createCouponFail() {
        int deployAmount = 100;
        CouponGroup persistentCouponGroup = couponGroupRepository.save(getDeployedCouponGroup(
                CouponDeploy.getDeployLimitInstance(deployAmount)
        ));
        couponDeployAmountRepository.deploy(persistentCouponGroup.getId(), deployAmount);
        Long memberId = 1L;
        LocalDate now = LocalDate.of(3024, 12, 31);

        assertThatCode(() -> couponCommandService.create(memberId, persistentCouponGroup.getId(), now))
                .isInstanceOf(CouponGroupExpiredException.class);
        assertThat(couponDeployAmountRepository.getCouponDeployAmount(persistentCouponGroup.getId()))
                .isEqualTo(deployAmount);
        couponDeployAmountRepository.clear(persistentCouponGroup.getId());
    }
```